### PR TITLE
feat: :rocket: Make Hamburger menu icon responsive

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -558,6 +558,7 @@
 	.vect-bg {display: none;}
 	.latest-works-section .row {margin: 0;}
 	.togglee-it {margin-bottom: 40px;}
+	.header-content .icons-list{display: flex;}
 }
 
 

--- a/css/style.css
+++ b/css/style.css
@@ -721,7 +721,7 @@ nav ul li.active > a {
 	float: right;
 	text-align: right;
 	margin-left: 0;
-	display: inline-flex;
+	display: none;
 	align-items: center;
 }
 .icons-list li {


### PR DESCRIPTION
I made the hamburger icon responsive at 768px viewport, which is standard for tablet view. 

#### Screenshot
- Screen size < 768px 
![image](https://user-images.githubusercontent.com/70312106/135627462-57d0a4b7-19a4-45f5-996d-a16a44a0a019.png)
- Screen size > 768px
![image](https://user-images.githubusercontent.com/70312106/135627542-ecd7d758-9e2d-4373-b695-1033cead9e33.png)

