### PR TITLE
Improves clubhouse, youtube and linkedin tile click area (also for mobile)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2200,7 +2200,6 @@ header nav ul li.has-mega-menu:hover > .mega-menu ul {
   -o-box-shadow: 0 0 30px rgba(227, 239, 240, 0.7);
   box-shadow: 0 0 30px rgba(227, 239, 240, 0.7);
   text-align: center;
-  padding: 72px 0;
   margin-bottom: 30px;
   margin-right: 30px;
   transition: transform 0.25s;
@@ -2223,6 +2222,13 @@ header nav ul li.has-mega-menu:hover > .mega-menu ul {
   color: #393e46;
   font-size: 20px;
   font-weight: 700;
+}
+
+.abt-proptz2 ul li > a {
+  padding: 72px 0;
+  display: block;
+  width: 100%;
+  height: 100%
 }
 
 .more-sectat2 .about-text {


### PR DESCRIPTION
Hey,

I recognized that the links are only clickable on the text on the icon.
IMHO it makes sense that the whole tile is clickable.

This would solve #23.

Best regards,
ewatch